### PR TITLE
EDNS0 changes, refactoring OPTRR and Query 

### DIFF
--- a/src/main/java/edu/msudenver/cs/jdnss/Header.java
+++ b/src/main/java/edu/msudenver/cs/jdnss/Header.java
@@ -77,9 +77,9 @@ class Header
         // only grab the header from the query
         this.header = Arrays.copyOf(buffer, 12);
 
-        id =            Utils.addThem(buffer[0], buffer[1]);
-        numQuestions =  Utils.addThem(buffer[4], buffer[5]);
-        numAnswers =    Utils.addThem(buffer[6], buffer[7]);
+        id             =Utils.addThem(buffer[0], buffer[1]);
+        numQuestions   =Utils.addThem(buffer[4], buffer[5]);
+        numAnswers     =Utils.addThem(buffer[6], buffer[7]);
         numAuthorities =Utils.addThem(buffer[8], buffer[9]);
         numAdditionals =Utils.addThem(buffer[10], buffer[11]);
 

--- a/src/main/java/edu/msudenver/cs/jdnss/Query.java
+++ b/src/main/java/edu/msudenver/cs/jdnss/Query.java
@@ -67,6 +67,7 @@ class Query {
 
         int location = 12;
         queries = new Queries[header.getNumQuestions()];
+        
 
         for (int i = 0; i < header.getNumQuestions(); i++) {
             Vector<Object> StringAndNumber = Utils.parseName(location, buffer);
@@ -90,11 +91,34 @@ class Query {
             */
         }
 
+
+        /* For servers with DNS Cookies enabled, the QUERY opcode behavior is
+        extended to support queries with an empty Question Section (a QDCOUNT
+            of zero (0)), provided that an OPT record is present with a COOKIE
+        option.  Such servers will send a reply that has an empty
+        Answer Section and has a COOKIE option containing the Client Cookie
+        and a valid Server Cookie. */
+
+         /*
+        At a server where DNS Cookies are not implemented and enabled, the
+        presence of a COOKIE option is ignored and the server responds as if
+        no COOKIE option had been included in the request.
+        */
+
         for (int i = 0; i < header.getNumAdditionals(); i++) {
+            logger.traceEntry();
             // for now, it has to be 1
             Assertion.aver(header.getNumAdditionals() == 1);
 
             optrr = new OPTRR(Arrays.copyOfRange(buffer, location, buffer.length));
+
+            // check for invalid cookies
+            if ( optrr.getOptionLength() < 8 || (optrr.getOptionLength() > 8 && optrr.getOptionLength() < 16)
+                || optrr.getOptionLength() > 40){
+                // need to set the RCODE in header for the response needs to be FORMERR
+                header.setRcode( ErrorCodes.FORMERROR.getCode() );
+
+            }else{}
         }
     }
 

--- a/src/main/java/edu/msudenver/cs/jdnss/Query.java
+++ b/src/main/java/edu/msudenver/cs/jdnss/Query.java
@@ -110,6 +110,9 @@ class Query {
             // for now, it has to be 1
             Assertion.aver(header.getNumAdditionals() == 1);
 
+
+            logger.trace(Arrays.copyOfRange(buffer, location, buffer.length).toString());
+
             optrr = new OPTRR(Arrays.copyOfRange(buffer, location, buffer.length));
 
             // check for invalid cookies
@@ -119,6 +122,7 @@ class Query {
                 header.setRcode( ErrorCodes.FORMERROR.getCode() );
 
             }else{}
+
         }
     }
 

--- a/src/main/java/edu/msudenver/cs/jdnss/RR.java
+++ b/src/main/java/edu/msudenver/cs/jdnss/RR.java
@@ -748,7 +748,11 @@ class OPTRR {
         Assertion.aver(type == 41);
 
         payloadSize = Utils.addThem(bytes[location++], bytes[location++]);
+        logger.trace(payloadSize);
+
         extendedrcode = bytes[location++];
+        logger.trace(extendedrcode);
+
         version = bytes[location++];
         Assertion.aver(version == 0);
 
@@ -757,107 +761,42 @@ class OPTRR {
         // logger.error(flags);
         DNSSEC = flags >> 15 == 1; // DNSSEC OK bit as defined by [RFC3225].
         // logger.error(DNSSEC);
+        logger.trace(DNSSEC);
 
         rdLength = Utils.addThem(bytes[location++], bytes[location++]);
+        logger.trace(rdLength);
 
-        optionCode = Utils.addThem(bytes[location++], bytes[location++]);
-        Assertion.aver(optionCode == 10);
+        if (rdLength >= 5 ) { //data length needs to be minimum of 5 bytes
 
-        optionLength = Utils.addThem(bytes[location++], bytes[location++]);
-        logger.traceEntry();
+            optionCode = Utils.addThem(bytes[location++], bytes[location++]);
+            Assertion.aver(optionCode == 10);
 
-
-        /*
-        If the COOKIE option is too short to contain a Client Cookie, then
-        FORMERR is generated.  If the COOKIE option is longer than that
-        required to hold a COOKIE option with just a Client Cookie (8 bytes)
-        but is shorter than the minimum COOKIE option with both a
-        Client Cookie and a Server Cookie (16 bytes), then FORMERR is
-        generated.  If the COOKIE option is longer than the maximum valid
-        COOKIE option (40 bytes), then FORMERR is generated.
-        */
-
-
-
-        clientCookie = Arrays.copyOfRange(bytes, location, location + 8);
-        location += 8;
-
-        logger.error(clientCookie);
-
-        if (optionLength > 8) { // server cookie returned
-            // OPTION-LENGTH >= 16, <= 40 [rfc7873]
-            Assertion.aver(optionLength == 16
-                                || optionLength == 24
-                                || optionLength == 32
-                                || optionLength == 40);
+            optionLength = Utils.addThem(bytes[location++], bytes[location++]);
 
             /*
-            The Server Cookie SHOULD consist of or include a 64-bit or larger
-            pseudorandom function of the request source (client) IP address, a
-            secret quantity known only to the server, and the request
-            Client Cookie.
-
-            The Server Cookie is an integer number of bytes, with a minimum size
-            of 8 bytes for security and a maximum size of 32 bytes for convenience
-            of implementation.
-
-            Thus, clients and servers are configured with a
-            lifetime setting for their secret, and they roll over to a new secret
-            when that lifetime expires, or earlier due to deliberate jitter as
-            described below.  The default lifetime is one day, and the maximum
-            permitted is one month.
-
-            For servers with DNS Cookies enabled, the QUERY opcode behavior is
-            extended to support queries with an empty Question Section (a QDCOUNT
-            of zero (0)), provided that an OPT record is present with a COOKIE
-            option.  Such servers will send a reply that has an empty
-            Answer Section and has a COOKIE option containing the Client Cookie
-            and a valid Server Cookie.
-
-            An example of a simple method producing a 64-bit Server Cookie is the
-            FNV64 [FNV] of the request IP address, the Client Cookie, and the
-            Server Secret.
-
-               Server Cookie =
-                  FNV64( Client IP Address | Client Cookie | Server Secret )
-
-            where "|" represents concatenation.
-
-
-            https://github.com/jakedouglas/fnv-java/tree/master/src/main/java/com/bitlove
+            If the COOKIE option is too short to contain a Client Cookie, then
+            FORMERR is generated.  If the COOKIE option is longer than that
+            required to hold a COOKIE option with just a Client Cookie (8 bytes)
+            but is shorter than the minimum COOKIE option with both a
+            Client Cookie and a Server Cookie (16 bytes), then FORMERR is
+            generated.  If the COOKIE option is longer than the maximum valid
+            COOKIE option (40 bytes), then FORMERR is generated.
             */
-            serverCookie = Arrays.copyOfRange(bytes, location, location + optionLength - 8 );
+
+
+            clientCookie = Arrays.copyOfRange(bytes, location, location + 8);
+            location += 8;
+
+
+            if (optionLength > 8) { // server cookie returned
+                // OPTION-LENGTH >= 16, <= 40 [rfc7873]
+                Assertion.aver(optionLength == 16
+                    || optionLength == 24
+                    || optionLength == 32
+                    || optionLength == 40);
+
+                serverCookie = Arrays.copyOfRange(bytes, location, location + optionLength - 8);
+            }
         }
     }
-
-    /*
-    public byte[] getBytes() {
-        int minttl = ttl == 0 ? TTLminimum : ttl;
-
-        byte name[] = Utils.convertString(question);
-
-        byte rdata[] = getBytes();
-        int rdatalen = rdata.length;
-
-        int count = name.length + 2 + 2 + 4 + 2 + rdatalen;
-
-        byte a[] = new byte[count];
-        System.arraycopy(name, 0, a, 0, name.length);
-
-        int where = name.length;
-
-        a[where++] = Utils.getByte(type, 2);
-        a[where++] = Utils.getByte(type, 1);
-        a[where++] = Utils.getByte(rrclass, 2);
-        a[where++] = Utils.getByte(rrclass, 1);
-        a[where++] = Utils.getByte(minttl, 4);
-        a[where++] = Utils.getByte(minttl, 3);
-        a[where++] = Utils.getByte(minttl, 2);
-        a[where++] = Utils.getByte(minttl, 1);
-        a[where++] = Utils.getByte(rdatalen, 2);
-        a[where++] = Utils.getByte(rdatalen, 1);
-        System.arraycopy(rdata, 0, a, where, rdata.length);
-
-        return a;
-    } */
 }


### PR DESCRIPTION
you can now run a `dig @localhost test.com` against JDNSS and it will reply, there are still issues however as the response is placing the OPTRR in the answer section instead of the additional section - which I believe is incorrect. 