### PR TITLE
Passing client ip address to the ServerCookie to correctly build it

### DIFF
--- a/src/main/java/edu/msudenver/cs/jdnss/OPTRR.java
+++ b/src/main/java/edu/msudenver/cs/jdnss/OPTRR.java
@@ -114,9 +114,9 @@ class OPTRR {
      from a valid client cookie
      adds this serverCookie to this OPTRR
      */
-    protected void addServerCookie(){
+    protected void addServerCookie(String clientIPaddress){
         //TODO check that server cookie does not already exist
-        ServerCookie sc = new ServerCookie(clientCookie);
+        ServerCookie sc = new ServerCookie(clientCookie, clientIPaddress);
         this.serverCookie = sc.getBytes();
         this.optionLength += serverCookie.length;
         this.rdLength += serverCookie.length;

--- a/src/main/java/edu/msudenver/cs/jdnss/Query.java
+++ b/src/main/java/edu/msudenver/cs/jdnss/Query.java
@@ -42,7 +42,7 @@ class Query {
     /**
      * Evaluates and saves all questions
      */
-    public void parseQueries() {
+    public void parseQueries(String clientIPaddress) {
         logger.traceEntry();
 
         /*
@@ -120,7 +120,8 @@ class Query {
             }
             else if(optrr.hasCookie()){
                 //TODO check for invalid cookie
-                optrr.addServerCookie();
+                //TODO ipaddres & serversercret
+                optrr.addServerCookie(clientIPaddress);
 
             }
             /*

--- a/src/main/java/edu/msudenver/cs/jdnss/TCPThread.java
+++ b/src/main/java/edu/msudenver/cs/jdnss/TCPThread.java
@@ -56,7 +56,7 @@ class TCPThread implements Runnable {
         }
 
         Query q = new Query(query);
-        q.parseQueries();
+        q.parseQueries(socket.getInetAddress().toString());
 
         Response r = new Response(q);
         byte b[] = r.makeResponses(false);

--- a/src/main/java/edu/msudenver/cs/jdnss/UDPThread.java
+++ b/src/main/java/edu/msudenver/cs/jdnss/UDPThread.java
@@ -54,7 +54,7 @@ public class UDPThread implements Runnable
         logger.traceEntry();
 
         Query query = new Query (packet);
-        query.parseQueries();
+        query.parseQueries(address.toString());
 
         Response r = new Response(query);
         byte b[] = r.makeResponses(true);

--- a/src/test/java/edu/msudenver/cs/jdnss/QueryTest.java
+++ b/src/test/java/edu/msudenver/cs/jdnss/QueryTest.java
@@ -56,9 +56,9 @@ public class QueryTest
 
     @Before
     public void setUp() throws Exception {
-        query.parseQueries();
-        digQuery.parseQueries();
-        digQueryDNSSEC.parseQueries();
+        query.parseQueries("");
+        digQuery.parseQueries("");
+        digQueryDNSSEC.parseQueries("");
     }
 
     @After


### PR DESCRIPTION
Resolve #16 for the time being. Will correctly "transport" the client IP address to where we need it but not in a preferred way.